### PR TITLE
延期ボタンを押したときの挙動を変更

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,10 +22,20 @@ func main() {
 
 	e.GET("/ping", ping)
 	e.POST("/callback", line.Callback)
+	e.GET("/training", training)
+	e.GET("/snooze", snooze)
 
 	e.Logger.Fatal(e.Start(":" + os.Getenv("PORT")))
 }
 
 func ping(c echo.Context) error {
 	return c.String(http.StatusOK, "pong")
+}
+
+func training(c echo.Context) error {
+	return c.Redirect(http.StatusPermanentRedirect, "shortcuts://run-shortcut?name=takken-go")
+}
+
+func snooze(c echo.Context) error {
+	return c.Redirect(http.StatusPermanentRedirect, "shortcuts://run-shortcut?name=takken-go/snooze")
 }

--- a/line/postback.go
+++ b/line/postback.go
@@ -9,8 +9,9 @@ type Action string
 
 const (
 	AnswerAction Action = "answer"
-	SnoozeAction Action = "snooze"
 	ScoreAction  Action = "score"
+	// TODO: snooze ポストバックは使わない
+	SnoozeAction Action = "snooze"
 )
 
 type PostbackData struct {

--- a/line/training.go
+++ b/line/training.go
@@ -2,6 +2,7 @@ package line
 
 import (
 	"encoding/json"
+	"os"
 	"strconv"
 	"time"
 
@@ -123,8 +124,14 @@ func NewTrainingMessage() *linebot.FlexMessage {
 		Spacing:  linebot.FlexComponentSpacingTypeMd,
 	}
 
+	// TODO: あまり有効でない関数の使用 (NewTrainingButton)
 	answer := NewTrainingButton("解答", AnswerAction, id, linebot.FlexButtonStyleTypePrimary)
-	snooze := NewTrainingButton("延期", SnoozeAction, id, linebot.FlexButtonStyleTypeSecondary)
+	snooze := &linebot.ButtonComponent{
+		Type: linebot.FlexComponentTypeButton,
+		Action: linebot.NewURIAction("延期", os.Getenv("ORIGIN") + "/snooze"),
+		Height: linebot.FlexButtonHeightTypeSm,
+		Style: linebot.FlexButtonStyleTypeSecondary,
+	}
 
 	footer := linebot.BoxComponent{
 		Type:     linebot.FlexComponentTypeBox,


### PR DESCRIPTION
延期ボタンを押したときの挙動について、アラームを設定するショートカットの実行リンクをテキストメッセージとして送信していましたが、ボタンのアクションをURIアクションとして、リダイレクトでショートカットの実行リンクを踏ませるようにしました。