### PR TITLE
出題ロジックのバグを修正

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -37,7 +37,7 @@ func choiceLowest(list []float64) int {
 	r := rand.Float64() * max
 	for i, c := range cum {
 		if c > r {
-			return i
+			return i + 1
 		}
 	}
 	return -1
@@ -46,7 +46,7 @@ func choiceLowest(list []float64) int {
 func GetRatesList() (ratesList []float64) {
 	db := openDB()
 	defer closeDB(db)
-	rows, err := db.Query("select  rate from questions")
+	rows, err := db.Query("select  rate from questions order by id")
 	if err != nil {
 		log.Println(err)
 		return nil


### PR DESCRIPTION
出題の処理に2点バグがあり、これを修正しました。

一つ目は、データベースから正答率を取得するときに、SELECT文に ORDER を指定していなかったためスライスに格納される値が実際の正答率のリストに対応していないというものでした。これは該当する SQL に ORDER BY id を追加して対応しました。

二つ目は、ソースコード内で id を 0-indexed で管理していたため、出題すべき問題の一つ前の問題が出題されてしまうというものです。こちらは出題を決定する関数の返り値をインクリメントすることで対応しました。